### PR TITLE
Update xero_app.rb

### DIFF
--- a/xero_app.rb
+++ b/xero_app.rb
@@ -111,7 +111,8 @@ end
 # This endpoint shows invoice data via the 'invoices.haml' view.
 get '/invoices' do
   xero_client.set_token_set(session[:token_set])
-  @invoices = xero_client.accounting_api.get_invoices(xero_client.connections[0]['tenantId']).invoices
+  tenant_id = xero_client.connections[0]['tenantId']
+  @invoices = xero_client.accounting_api.get_invoices(tenant_id).invoices
   haml :invoices
 end
 
@@ -119,12 +120,14 @@ end
 # in the xero_client.connections array.
 get '/organisation' do
   xero_client.set_token_set(session[:token_set])
-  @organisations = xero_client.accounting_api.get_organisations(xero_client.connections[0]['tenantId']).organisations
+  tenant_id = xero_client.connections[0]['tenantId']
+  @organisations = xero_client.accounting_api.get_organisations(tenant_id).organisations
   haml :organisation
 end
 
 get '/reports' do
   xero_client.set_token_set(session[:token_set])
-  @reports = xero_client.accounting_api.get_report_ba_sor_gst_list(xero_client.connections[0]['tenantId']).reports
+  tenant_id = xero_client.connections[0]['tenantId']
+  @reports = xero_client.accounting_api.get_report_ba_sor_gst_list(tenant_id).reports
   haml :reports
 end


### PR DESCRIPTION
fixes setting the tenant_id, this was making two calls at the same time, causing confusion with the URL that should be used for each.